### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,13 +94,14 @@ services:
     environment:
       APP_INSTALLATION: "opensource"
       APP_ENV: "prod"
+      AUTH_ENV: ${AUTH_ENV:-"demo"}
       MASTER_TOKEN: "fake-us-master-token"
       POSTGRES_DSN_LIST: ${METADATA_POSTGRES_DSN_LIST:-postgres://us:us@pg-us:5432/us-db-ci_purgeable}
       SKIP_INSTALL_DB_EXTENSIONS: ${METADATA_SKIP_INSTALL_DB_EXTENSIONS:-0}
       USE_DEMO_DATA: ${USE_DEMO_DATA:-1}
       HC: ${HC:-0}
       NODE_EXTRA_CA_CERTS: /certs/root.crt
-      NODE_RPC_URL: ${NODE_RPC_URL:-http://auth/${AUTH_ENV}/rpc}
+      NODE_RPC_URL: ${NODE_RPC_URL:-http://auth/$AUTH_ENV/rpc}
 
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
The ${} interpolation syntax is changed to use $AUTH_ENV directly without curly braces.